### PR TITLE
Fix lint-exception validation to ignore code blocks

### DIFF
--- a/tools/tests/test_data/_TEST_DATA_README.md
+++ b/tools/tests/test_data/_TEST_DATA_README.md
@@ -51,6 +51,27 @@ Markdown file with:
 
 ---
 
+### exceptions_in_code_blocks.md
+
+**Purpose:** Test that linter exceptions inside fenced code blocks are ignored
+
+Contains markdown with:
+
+- Real linter exceptions outside code blocks (should be counted)
+- Example linter exceptions inside ``` fenced code blocks (should be ignored)
+- Example linter exceptions inside ```` four-backtick blocks (should be ignored)
+- Both Vale and markdownlint exceptions
+
+**Used by:** `test_list_linter_exceptions.py`
+
+**Expected:**
+
+- 1 Vale exception (outside code blocks)
+- 1 markdownlint exception (outside code blocks)
+- Exceptions inside code blocks are NOT counted
+
+---
+
 ### edge_cases_front_matter.md
 
 **Purpose:** Test front matter parsing edge cases

--- a/tools/tests/test_data/exceptions_in_code_blocks.md
+++ b/tools/tests/test_data/exceptions_in_code_blocks.md
@@ -1,0 +1,47 @@
+# Test file: exceptions in code blocks
+
+This file has real exceptions and examples in code blocks.
+
+<!-- vale Google.Parens = NO -->
+
+This is a real exception that should be counted.
+
+Here's how to use Vale exceptions (this should NOT be counted):
+
+```markdown
+<!-- vale Google.Parens = NO -->
+Your content here
+<!-- vale Google.Parens = YES -->
+```
+
+Another real exception:
+
+<!-- markdownlint-disable MD013 -->
+
+And here's a MarkdownLint example (should NOT be counted):
+
+````markdown
+Example with four backticks:
+```bash
+curl http://example.com
+```
+
+And a linter exception:
+<!-- markdownlint-disable MD001 -->
+````
+
+Back to real content.
+
+<!-- vale Google.Parens = YES -->
+
+## Summary
+
+Expected counts:
+- Vale exceptions: 2 (lines 5 and 25)
+- MarkdownLint exceptions: 1 (line 19)
+- Total: 3 exceptions
+
+Should NOT count:
+- Line 10 (in triple-backtick code block)
+- Line 11 (in triple-backtick code block)
+- Line 24 (in four-backtick code block)


### PR DESCRIPTION
Updates `list-linter-exceptions.py` to ignore code in the code examples. The code in the code examples should be able to include linter exceptions without being flagged as an error.